### PR TITLE
[Feature] Header 공통 UI 컴포넌트 구현

### DIFF
--- a/src/components/common/Header/Header.jsx
+++ b/src/components/common/Header/Header.jsx
@@ -1,6 +1,72 @@
 import React from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import LOGO from '../../../assets/images/header-logo-img.svg';
+import CHAT from '../../../assets/icons/icon-chat.svg';
+import NOTIFYUNREAD from '../../../assets/icons/icon-notify-unread.svg';
+import NOTIFY from '../../../assets/icons/icon-notify.svg';
+import ADPROFILE from '../../../assets/images/profile-img-xxs.svg';
+import INFPROFILE from '../../../assets/images/profileInf-img-xxs.svg';
+import Search from '../Search/Search';
+import {
+  HeaderStyle,
+  Wrapper,
+  HeaderLeftStyle,
+  HeaderRightStyle,
+  MenuList,
+  Signup,
+  Login,
+} from './HeaderStyle';
+
 const Header = () => {
-  return <></>;
+  const navigate = useNavigate();
+
+  // 더미 데이터
+  const isLoggedIn = true;
+  const hasUnRead = false;
+  const isInfluncer = false;
+
+  return (
+    <>
+      <HeaderStyle>
+        <Wrapper>
+          <HeaderLeftStyle>
+            <h1 className="a11y">Celebrem 로고</h1>
+            <Link to="/">
+              <img src={LOGO} alt="celebrem 로고" />
+            </Link>
+            <Search />
+          </HeaderLeftStyle>
+          <HeaderRightStyle>
+            {isLoggedIn ? (
+              <MenuList>
+                <li>
+                  <img src={CHAT} alt="채팅 페이지로 가기" onClick={() => navigate('/chat')} />
+                  <span>채팅</span>
+                </li>
+                <li>
+                  <img src={hasUnRead ? NOTIFYUNREAD : NOTIFY} alt="알림" />
+                  <span>알림</span>
+                </li>
+                <li>
+                  <img
+                    src={isInfluncer ? INFPROFILE : ADPROFILE}
+                    alt="내 프로필로 가기"
+                    onClick={() => navigate('/profile')}
+                  />
+                  <span>마이 프로필</span>
+                </li>
+              </MenuList>
+            ) : (
+              <>
+                <Signup onClick={() => navigate('/signup')}>회원가입</Signup>
+                <Login onClick={() => navigate('/login')}>로그인</Login>
+              </>
+            )}
+          </HeaderRightStyle>
+        </Wrapper>
+      </HeaderStyle>
+    </>
+  );
 };
 
 export default Header;

--- a/src/components/common/Header/Header.jsx
+++ b/src/components/common/Header/Header.jsx
@@ -23,7 +23,7 @@ const Header = () => {
   // 더미 데이터
   const isLoggedIn = true;
   const hasUnRead = false;
-  const isInfluncer = false;
+  const isInfluencer = false;
 
   return (
     <>
@@ -49,11 +49,11 @@ const Header = () => {
                 </li>
                 <li>
                   <img
-                    src={isInfluncer ? INFPROFILE : ADPROFILE}
-                    alt="내 프로필로 가기"
-                    onClick={() => navigate('/profile')}
+                    src={isInfluencer ? INFPROFILE : ADPROFILE}
+                    alt="마이페이지로 가기"
+                    onClick={() => navigate('/mypage')}
                   />
-                  <span>마이 프로필</span>
+                  <span>마이 페이지</span>
                 </li>
               </MenuList>
             ) : (

--- a/src/components/common/Header/HeaderStyle.jsx
+++ b/src/components/common/Header/HeaderStyle.jsx
@@ -1,0 +1,67 @@
+import styled, { css } from 'styled-components';
+
+const HeaderStyle = styled.header`
+  width: 100%;
+  box-shadow: 0 4px 5px ${({ theme }) => theme.colors.gray100};
+`;
+
+const Wrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  max-width: 128rem;
+  margin: 0 auto;
+  padding: 1.5rem 1rem;
+`;
+
+const HeaderLeftStyle = styled.div`
+  display: flex;
+  align-items: center;
+  img {
+    width: 20rem;
+    height: 5rem;
+  }
+`;
+
+const HeaderRightStyle = styled.div`
+  img {
+    display: block;
+    margin: 0 auto 6px;
+    width: 3em;
+    height: 3rem;
+  }
+`;
+
+const MenuList = styled.ul`
+  display: flex;
+  li {
+    cursor: pointer;
+    margin-right: 3.6rem;
+    text-align: center;
+    font-size: ${({ theme }) => theme.fonts.s};
+    &:last-child {
+      margin-right: 0;
+    }
+  }
+`;
+
+const AuthLink = css`
+  font-size: ${({ theme }) => theme.fonts.md};
+  font-weight: bold;
+`;
+
+const Signup = styled.button`
+  ${AuthLink}
+  background: ${({ theme }) => theme.colors.main};
+  color: ${({ theme }) => theme.colors.white};
+  margin-right: 6.2rem;
+  padding: 1rem 3.2rem;
+  border-radius: 1rem;
+`;
+
+const Login = styled.button`
+  ${AuthLink}
+  color: ${({ theme }) => theme.colors.gray400};
+`;
+
+export { HeaderStyle, Wrapper, HeaderLeftStyle, HeaderRightStyle, MenuList, Signup, Login };

--- a/src/components/common/Search/Search.jsx
+++ b/src/components/common/Search/Search.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import styled from 'styled-components';
+import SEARCH from '../../../assets/icons/icon-search.svg';
+
+const Search = () => {
+  return (
+    <SearchForm>
+      <label htmlFor="search-input" className="a11y">
+        검색창
+      </label>
+
+      <SearchInput type="text" id="search-input" placeholder="인플루언서를 검색해보세요!" />
+      <SearchButton type="submit">
+        <img className="search" src={SEARCH} alt="검색 버튼" />
+      </SearchButton>
+    </SearchForm>
+  );
+};
+
+export default Search;
+
+const SearchForm = styled.form`
+  display: flex;
+  margin-left: 45px;
+`;
+
+const SearchInput = styled.input`
+  width: 400px;
+  height: 42px;
+  border: 2px solid ${({ theme }) => theme.colors.main};
+  border-radius: 5rem;
+  padding-left: 2.2rem;
+  color: ${({ theme }) => theme.colors.gray400};
+  font-size: ${({ theme }) => theme.fonts.base};
+  &::placeholder {
+    color: ${({ theme }) => theme.colors.gray200};
+    /* font-weight: normal; */
+  }
+`;
+
+const SearchButton = styled.button`
+  transform: translateX(-40px);
+  .search {
+    width: 2rem;
+    height: 2rem;
+  }
+`;

--- a/src/pages/HomePage/HomePage.jsx
+++ b/src/pages/HomePage/HomePage.jsx
@@ -1,16 +1,13 @@
 import React from 'react';
-import styled from 'styled-components';
+// import styled from 'styled-components';
+import Header from '../../components/common/Header/Header';
 
 const HomePage = () => {
   return (
     <>
-      <H1>홈페이지입니다</H1>
+      <Header />
     </>
   );
 };
 
 export default HomePage;
-
-const H1 = styled.h1`
-  color: ${({ theme }) => theme.colors.red};
-`;

--- a/src/pages/SignupPage/SignupPage.jsx
+++ b/src/pages/SignupPage/SignupPage.jsx
@@ -1,7 +1,11 @@
 import React from 'react';
 
 const SignupPage = () => {
-  return <></>;
+  return (
+    <>
+      <h1>회원가입 페이지</h1>
+    </>
+  );
 };
 
 export default SignupPage;


### PR DESCRIPTION
## 👑 무엇을 위한 PR인가요?
- [ ] 기능 추가 :
- [x] 스타일 : Header와 그 안에 Search 공통 UI 컴포넌트를 구현하였습니다.
- [ ] 리팩토링 :
- [ ] 문서 수정 : 
- [ ] 버그 수정 : 
- [ ] 기타 : 


## ⛅ 상세 작업 내용
- 후에 token 여부에 따라 header의 오른쪽 부분은 회원가입/로그인 또는 채팅, 알림, 마이페이지 버튼이 있습니다.
- image는 모두 대문자로 작성했는데 이부분도 논의가 필요할 것으로 보입니다! (컨벤션?)
- 스타일 컴포넌트 파일도 따로 분리했습니다! (추가 컨벤션)



## 🗯️ 전달 사항
- ![image](https://github.com/2023-D-coding-1th-TeamProject/Celebrem_frontend/assets/80268199/0cea5869-c7fc-4ca7-888e-b3e02b539510)
위에는 전의 header, 밑에는 수정된 header 디자인입니다.

## 📝 관련 이슈
- Close : #5 